### PR TITLE
Exclude external images to prevent cross-domain security error

### DIFF
--- a/build/retina.js
+++ b/build/retina.js
@@ -1,2 +1,41 @@
-(function(){1<window.devicePixelRatio&&(window.onload=function(){var b,g,c,h,d,f;d=document.getElementsByTagName("img");f=[];c=0;for(h=d.length;c<h;c++)b=d[c],f.push((g=function(){var e,a,c,d;if(b.complete){if(d=b.offsetWidth,c=b.offsetHeight,a=b.getAttribute("src").split("."),e=a.slice(0,a.length-1).join("."),a=a[a.length-1],e=""+e+"@2x."+a,a=new XMLHttpRequest,a.open("HEAD",e,!1),a.send(),200===a.status)return b.setAttribute("width",d),b.setAttribute("height",c),b.setAttribute("src",e)}else return setTimeout(g,
-5)})());return f})}).call(this);
+(function() {
+
+  if (window.devicePixelRatio > 1) {
+    window.onload = function() {
+      var image, is_external, load, _i, _len, _ref, _results;
+      is_external = function(href) {
+        return !!(href.match(/^https?\:/i) && !href.match(document.domain));
+      };
+      _ref = document.getElementsByTagName("img");
+      _results = [];
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        image = _ref[_i];
+        _results.push((load = function() {
+          var at_2x_path, extension, height, http, path, path_segments, path_without_extension, width;
+          if (!image.complete) {
+            return setTimeout(load, 5);
+          } else {
+            path = image.getAttribute("src");
+            if (is_external(path)) return;
+            width = image.offsetWidth;
+            height = image.offsetHeight;
+            path_segments = path.split('.');
+            path_without_extension = path_segments.slice(0, path_segments.length - 1).join(".");
+            extension = path_segments[path_segments.length - 1];
+            at_2x_path = "" + path_without_extension + "@2x." + extension;
+            http = new XMLHttpRequest();
+            http.open('HEAD', at_2x_path, false);
+            http.send();
+            if (http.status === 200) {
+              image.setAttribute('width', width);
+              image.setAttribute('height', height);
+              return image.setAttribute("src", at_2x_path);
+            }
+          }
+        })());
+      }
+      return _results;
+    };
+  }
+
+}).call(this);

--- a/src/retina.coffee
+++ b/src/retina.coffee
@@ -19,6 +19,10 @@
 if window.devicePixelRatio > 1 
   window.onload = ->
 
+    # Function to test if image is external
+    is_external = (href) ->
+      !!( href.match(/^https?\:/i) and !href.match(document.domain) )
+
     # Grab all of the <img> elements on the page and loop over them
     for image in document.getElementsByTagName("img")
 
@@ -36,6 +40,13 @@ if window.devicePixelRatio > 1
           setTimeout load, 5
           
         else
+
+          # Get image src
+          path = image.getAttribute("src")
+
+          # Return early if image has external path
+          if is_external(path)
+            return
           
           # Grab the image's in-place dimensions.
           width  = image.offsetWidth
@@ -44,7 +55,7 @@ if window.devicePixelRatio > 1
           # Split the file extension off the image path,
           # and put it back together with @2x before the extension.
           # "/path/to/image.png" => "/path/to/image@2x.png"
-          path_segments           = image.getAttribute("src").split('.')
+          path_segments           = path.split('.')
           path_without_extension  = path_segments.slice(0, (path_segments.length - 1)).join(".")
           extension               = path_segments[path_segments.length - 1]
           at_2x_path              = "#{path_without_extension}@2x.#{extension}"


### PR DESCRIPTION
This refers to the cross-domain error thrown if a page has images hosted on external domains (issue #3).

I branched this off of Master because I wasn't sure if you planned to merge in my previous pull request. And this is a more critical patch. If you do plan to merge the other pull request and would rather I submit this fix on top of that commit, let me know and I'll close this and resubmit.

Btw, sorry for being all up in your project! It's a cool idea and I've just been test driving it and noticing a few things. I know it's always fun when other people mess with your pretty code :)
