### PR TITLE
Support or non-webkit browsers with hi-res screens in retina.less

### DIFF
--- a/src/retina.less
+++ b/src/retina.less
@@ -5,8 +5,12 @@
   background-image: url(@path);
   @at2x_path: ~`"@{path}".split('.').slice(0, "@{path}".split('.').length - 1).join(".") + "@2x" + "." + "@{path}".split('.')["@{path}".split('.').length - 1]`;
 
-  @media all and (-webkit-min-device-pixel-ratio : 1.5) {
-    background-image: url(@at2x_path);
-    background-size: @w @h;
-  }  
-}
+  @media 
+    all and (-webkit-min-device-pixel-ratio : 1.5),
+    all and (-o-min-device-pixel-ratio: 3/2),
+    all and (min--moz-device-pixel-ratio: 1.5),
+    all and (min-device-pixel-ratio: 1.5) {
+      background-image: url(@at2x_path);
+      background-size: @w @h;
+    }  
+  }


### PR DESCRIPTION
Changed the output to 

@media 
    all and (-webkit-min-device-pixel-ratio : 1.5),
    all and (-o-min-device-pixel-ratio: 3/2),
    all and (min--moz-device-pixel-ratio: 1.5),
    all and (min-device-pixel-ratio: 1.5) {
      background-image: url(@at2x_path);
      background-size: @w @h;
    }  
  }

to support non-webkit browsers like Opera Mini/Mobile and Firefox for Android.
