### PR TITLE
Handle all non-error response codes

### DIFF
--- a/src/retina_image_path.coffee
+++ b/src/retina_image_path.coffee
@@ -40,7 +40,7 @@ class RetinaImagePath
       
       # If we get an A-OK from the server,
       # push file path onto array of confirmed files
-      if http.status is 200
+      if http.status in [200..399]
         RetinaImagePath.confirmed_paths.push @at_2x_path
         return true
       else


### PR DESCRIPTION
Right now, the `has_2x_variant` function only checks for a `200` response code. It should really check for all non-error response codes (the 2xx and 3xx range).

For example, this is a common scenario:

1) The client asks for an image.

2) The server responds to `has_2x_variant` with 200, you get the retina version.

3) Image is cached. The user visits the page again.

4) The server responds to `has_2x_variant` with 304 (not modified), you get the standard version.

Like (4) shows, you not only make an extra expensive http request but you also get a lower quality version of the image.
