### PR TITLE
Using asynchronous XMLHttpRequest for not blocking the browser

### DIFF
--- a/src/retina_image.coffee
+++ b/src/retina_image.coffee
@@ -4,7 +4,9 @@ class RetinaImage
 
   constructor: (@el) ->
     @path = new RetinaImagePath(@el.getAttribute('src'))
-    @swap() if @path.has_2x_variant()
+    @path.check_2x_variant (swap) =>
+      if (swap)
+        @swap()
 
 
 
@@ -13,26 +15,51 @@ class RetinaImage
   # to the image with the new image path
   swap: (path = @path.at_2x_path) ->
 
-    # We wrap this in a named self-executer so we can reference 
+    # We wrap this in a named self-executer so we can reference
     # it in a setTimeout if the image has not loaded yet.
     do load = =>
 
       # Check that the image has loaded.
       # We need to wait for the image to load to grab proper dimensions.
-      unless @el.complete  
+      unless @el.complete
 
         # If it has not, try again in a few milliseconds.
         # We've found 5ms to be the fastest we can crank this up
         # and still have the script detect image loads reliably and efficiently.
         setTimeout load, 5
 
-      # Once the the image has loaded we know we 
+      # Once the the image has loaded we know we
       # can grab the proper dimensions of the original image
       # and go ahead and swap in the new image path and apply the dimensions
-      else        
-        @el.setAttribute('width', @el.offsetWidth)
-        @el.setAttribute('height', @el.offsetHeight)
-        @el.setAttribute('src', path)
+      else
+        swap = true;
+
+        # If offsetWidth is 0, the image is probably hidden
+        if @el.offsetWidth != 0
+          width = @el.offsetWidth
+        else
+          # try to get width from the image attribute
+          if @el.getAttribute('width')
+            width = @el.getAttribute('width')
+          else
+            # we have no knowledge about the width, abort because it
+            # would brake the image size
+            swap = false;
+
+        # Same also for the height
+        if @el.offsetHeight != 0
+          height = @el.offsetHeight
+        else
+          if @el.getAttribute('height')
+            height = @el.getAttribute('height')
+          else
+            swap = false;
+
+
+        if (swap)
+          @el.setAttribute('width', width)
+          @el.setAttribute('height', height)
+          @el.setAttribute('src', path)
 
 
 root = exports ? window

--- a/src/retina_image_path.coffee
+++ b/src/retina_image_path.coffee
@@ -1,9 +1,9 @@
 class RetinaImagePath
-  
-  # Class variable [Array] 
+
+  # Class variable [Array]
   # cache of files we've checked on the server
   @confirmed_paths = []
-  
+
 
   constructor: (@path) ->
     # Split the file extension off the image path,
@@ -19,33 +19,38 @@ class RetinaImagePath
   is_external: ->
     !!( @path.match(/^https?\:/i) and !@path.match('//' + document.domain) )
 
-  has_2x_variant: ->
+  check_2x_variant: (callback) ->
+    @callback = callback
+
     # If the image path is on an external server,
     # exit early to avoid cross-domain ajax errors
     if @is_external()
-      return false
+      @callback false
+      return
 
     # If we have already checked and confirmed that
     # the @2x variant exists, then just return true
-    else if @at_2x_path in RetinaImagePath.confirmed_paths
-      return true
+    if @at_2x_path in RetinaImagePath.confirmed_paths
+      @callback true
+      return
 
     # Otherwise, prepare an AJAX request for the HEAD only.
     # We don't need a full request because we're only
     # checking to see if the @2x version exists on the server
     else
       http = new XMLHttpRequest
-      http.open('HEAD', @at_2x_path, false)
+      http.open('HEAD', @at_2x_path)
+      http.onreadystatechange = () =>
+        if http.readyState != 4
+          return
+        if http.status in [200..399]
+          RetinaImagePath.confirmed_paths.push @at_2x_path
+          @callback true
+        else
+          @callback false
       http.send()
-      
-      # If we get an A-OK from the server,
-      # push file path onto array of confirmed files
-      if http.status in [200..399]
-        RetinaImagePath.confirmed_paths.push @at_2x_path
-        return true
-      else
-        return false
-    
+      return
+
 
 root = exports ? window
 root.RetinaImagePath = RetinaImagePath

--- a/test/fixtures/xml_http_request.coffee
+++ b/test/fixtures/xml_http_request.coffee
@@ -1,12 +1,16 @@
 class XMLHttpRequest
   @status = 200
+  @onreadystatechange
 
-  constructor: -> 
+  constructor: ->
     @status = XMLHttpRequest.status
+    @readyState = 4
 
   open: -> true
 
-  send: -> true
-        
+  send: =>
+    @onreadystatechange()
+
+
 root = exports ? window
 root.XMLHttpRequest = XMLHttpRequest

--- a/test/retina_image_path.test.coffee
+++ b/test/retina_image_path.test.coffee
@@ -76,33 +76,42 @@ describe 'RetinaImagePath', ->
       path.is_external().should.equal false    
     
 
-  describe '#has_2x_variant()', ->    
-    it 'should return false when #is_external() is true', ->
+
+  describe '#check_2x_variant()', ->
+    it 'should callback with false when #is_external() is true', (done) ->
       document.domain = "www.apple.com"
       path = new RetinaImagePath("http://google.com/images/some_image.png")
-      path.has_2x_variant().should.equal false
+      path.check_2x_variant (response) ->
+        response.should.equal false
+        done()
 
-
-    it 'should return false when remote at2x image does not exist', ->
+    it 'should callback with false when remote at2x image does not exist', (done) ->
       XMLHttpRequest.status = 404 # simulate a failing request
       path = new RetinaImagePath("/images/some_image.png")
-      path.has_2x_variant().should.equal false
-      
+      path.check_2x_variant (response) ->
+        response.should.equal false
+        done()
 
-    it 'should return true when remote at2x image exists', ->
+
+    it 'should callback with true when remote at2x image exists', (done) ->
       XMLHttpRequest.status = 200 # simulate a proper request
       path = new RetinaImagePath("/images/some_image.png")
-      path.has_2x_variant().should.equal true
+      path.check_2x_variant (response) ->
+        response.should.equal true
+        done()
 
-
-    it 'should add path to cache when at2x image exists', ->
+    it 'should add path to cache when at2x image exists', (done) ->
       XMLHttpRequest.status = 200 # simulate a proper request
       path = new RetinaImagePath("/images/some_image.png")
-      path.has_2x_variant()
-      RetinaImagePath.confirmed_paths.should.include path.at_2x_path
+      @RetinaImagePath = RetinaImagePath
+      path.check_2x_variant () =>
+        @RetinaImagePath.confirmed_paths.should.include path.at_2x_path
+        done()
 
 
-    it 'should return true when the at2x image path has already been checked and confirmed', ->
+    it 'should callback with true when the at2x image path has already been checked and confirmed', (done) ->
       RetinaImagePath.confirmed_paths = ['/images/some_image@2x.png']
       path = new RetinaImagePath("/images/some_image.png")
-      path.has_2x_variant().should.equal true
+      path.check_2x_variant (response) ->
+        response.should.equal true
+        done()


### PR DESCRIPTION
I'm using retina.js on http://www.osec.ch/de which is a pretty Image heavy Page. The @2x Images are created on the fly with GD2, which can take sometimes quite long (500ms) because the images are big.

I encountered that on pages like the Startpage that during the HEAD XMLHttpRequests the whole Browser is stuck, no scrolling, no clicking, etc. Safari even shows the Beachball. After some research I found that you are actually using synchronous XMLHttpRequests which is the reason.

This change fixes this with using asynchronous XMLHttpRequest. I changed <pre>has_2x_variant</pre> to <pre>check_2x_variant</pre> with a callback function which gets true or false depending if the image has an 2x variant.

Also updated all tests.
