### PR TITLE
Using asynchronous XMLHttpRequest for not blocking the browser

### DIFF
--- a/src/retina_image.coffee
+++ b/src/retina_image.coffee
@@ -4,7 +4,9 @@ class RetinaImage
 
   constructor: (@el) ->
     @path = new RetinaImagePath(@el.getAttribute('src'))
-    @swap() if @path.has_2x_variant()
+    @path.check_2x_variant (swap) =>
+      if (swap)
+        @swap()
 
 
 

--- a/test/fixtures/xml_http_request.coffee
+++ b/test/fixtures/xml_http_request.coffee
@@ -1,12 +1,16 @@
 class XMLHttpRequest
   @status = 200
+  @onreadystatechange
 
   constructor: -> 
     @status = XMLHttpRequest.status
+    @readyState = 4
 
   open: -> true
 
-  send: -> true
-        
+  send: =>
+    @onreadystatechange()
+
+
 root = exports ? window
 root.XMLHttpRequest = XMLHttpRequest

--- a/test/retina_image_path.test.coffee
+++ b/test/retina_image_path.test.coffee
@@ -76,33 +76,42 @@ describe 'RetinaImagePath', ->
       path.is_external().should.equal false    
     
 
-  describe '#has_2x_variant()', ->    
-    it 'should return false when #is_external() is true', ->
+
+  describe '#check_2x_variant()', ->
+    it 'should callback with false when #is_external() is true', (done) ->
       document.domain = "www.apple.com"
       path = new RetinaImagePath("http://google.com/images/some_image.png")
-      path.has_2x_variant().should.equal false
+      path.check_2x_variant (response) ->
+        response.should.equal false
+        done()
 
-
-    it 'should return false when remote at2x image does not exist', ->
+    it 'should callback with false when remote at2x image does not exist', (done) ->
       XMLHttpRequest.status = 404 # simulate a failing request
       path = new RetinaImagePath("/images/some_image.png")
-      path.has_2x_variant().should.equal false
-      
+      path.check_2x_variant (response) ->
+        response.should.equal false
+        done()
 
-    it 'should return true when remote at2x image exists', ->
+
+    it 'should callback with true when remote at2x image exists', (done) ->
       XMLHttpRequest.status = 200 # simulate a proper request
       path = new RetinaImagePath("/images/some_image.png")
-      path.has_2x_variant().should.equal true
+      path.check_2x_variant (response) ->
+        response.should.equal true
+        done()
 
-
-    it 'should add path to cache when at2x image exists', ->
+    it 'should add path to cache when at2x image exists', (done) ->
       XMLHttpRequest.status = 200 # simulate a proper request
       path = new RetinaImagePath("/images/some_image.png")
-      path.has_2x_variant()
-      RetinaImagePath.confirmed_paths.should.include path.at_2x_path
+      @RetinaImagePath = RetinaImagePath
+      path.check_2x_variant () =>
+        @RetinaImagePath.confirmed_paths.should.include path.at_2x_path
+        done()
 
 
-    it 'should return true when the at2x image path has already been checked and confirmed', ->
+    it 'should callback with true when the at2x image path has already been checked and confirmed', (done) ->
       RetinaImagePath.confirmed_paths = ['/images/some_image@2x.png']
       path = new RetinaImagePath("/images/some_image.png")
-      path.has_2x_variant().should.equal true
+      path.check_2x_variant (response) ->
+        response.should.equal true
+        done()


### PR DESCRIPTION
I'm using retina.js on http://www.osec.ch/de which is a pretty Image heavy page. The @2x Images are created on the fly with GD2, which can take sometimes quite long (500ms) because the images are big.

I encountered that on pages like the Startpage that during the HEAD XMLHttpRequests the whole Browser is stuck, no scrolling, no clicking, etc. Safari even shows the Beachball. After some research I found that you are actually using synchronous XMLHttpRequests which is the reason.

This change fixes this with using asynchronous XMLHttpRequest. I changed <pre>has_2x_variant</pre> to <pre>check_2x_variant</pre> with a callback function which gets true or false depending if the image has an 2x variant.

Also updated all tests.
