### PR TITLE
Checking width & height correctly for hidden images

### DIFF
--- a/src/retina_image.coffee
+++ b/src/retina_image.coffee
@@ -29,10 +29,35 @@ class RetinaImage
       # Once the the image has loaded we know we 
       # can grab the proper dimensions of the original image
       # and go ahead and swap in the new image path and apply the dimensions
-      else        
-        @el.setAttribute('width', @el.offsetWidth)
-        @el.setAttribute('height', @el.offsetHeight)
-        @el.setAttribute('src', path)
+      else
+        swap = true;
+
+        # If offsetWidth is 0, the image is probably hidden
+        if @el.offsetWidth != 0
+          width = @el.offsetWidth
+        else
+          # try to get width from the image attribute
+          if @el.getAttribute('width')
+            width = @el.getAttribute('width')
+          else
+            # we have no knowledge about the width, abort because it
+            # would brake the image size
+            swap = false;
+
+        # Same also for the height
+        if @el.offsetHeight != 0
+          height = @el.offsetHeight
+        else
+          if @el.getAttribute('height')
+            height = @el.getAttribute('height')
+          else
+            swap = false;
+
+
+        if (swap)
+          @el.setAttribute('width', width)
+          @el.setAttribute('height', height)
+          @el.setAttribute('src', path)
 
 
 root = exports ? window


### PR DESCRIPTION
On http://www.osec.ch/de we have an image slider, which hides the currently not shown Images with display:none. The Problem is now, that ".offsetWidth" returns 0 for hidden images and this causes retina.js to show the @2x image with width=0 and height=0.

This commit adds an additionally check:
- If offsetWidth is not 0 using this value
- If offsetWidth is 0 check if there is an width attribute for the img tag, and use this
- If also no width attribute, stop swapping
