### PR TITLE
Added media query matches for more browsers

### DIFF
--- a/src/retina.less
+++ b/src/retina.less
@@ -5,10 +5,10 @@
 
 .at2x(@path, @w: auto, @h: auto) {
   background-image: url(@path);
-  @at2x_path: ~`"@{path}".replace(/\.\w+$/, function(match) { return "@2x" + match; })`;
+  @at2x_path: ~`@{path}.replace(/\.\w+$/, function(match) { return "@2x" + match; })`;
 
   @media @highdpi {
-    background-image: url(@at2x_path);
+    background-image: url("@{at2x_path}");
     background-size: @w @h;
   }
 }

--- a/test/fixtures/desired_output.css
+++ b/test/fixtures/desired_output.css
@@ -1,9 +1,18 @@
 body {
   background-image: url('/path/to/image.png');
 }
-@media all and (-webkit-min-device-pixel-ratio: 1.5) {
+@media (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx) {
   body {
-    background-image: url('/path/to/image@2x.png');
+    background-image: url("/path/to/image@2x.png");
     background-size: 200px 100px;
+  }
+}
+header {
+  background-image: url("/path/to/header.png");
+}
+@media (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx) {
+  header {
+    background-image: url("/path/to/header@2x.png");
+    background-size: 600px 50px;
   }
 }

--- a/test/fixtures/test.less
+++ b/test/fixtures/test.less
@@ -1,6 +1,10 @@
 @import 'src/retina';
 
+// Single quoted
 body {
   .at2x('/path/to/image.png', 200px, 100px);
 }
-
+// Double quoted
+header {
+  .at2x("/path/to/header.png", 600px, 50px);
+}


### PR DESCRIPTION
Hey, this project was just what I was looking for. Awesome stuff.

Added relevant browser matches for the retina media query.
The min--moz query is used by FF up to version 15. FF >= 16 has the new pimping dppx unit.
http://www.w3.org/TR/css3-values/#dppx
http://www.w3.org/blog/CSS/2012/06/14/unprefix-webkit-device-pixel-ratio/
This is supposedly the way other browsers will implement it too.

Had to escape the media matches, the less parser was chocking on the dppx unit. 

Also made the path codes a bit more readable.

Cheers
