### PR TITLE
add a media query for browsers that do not support devicePixelRatio

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -104,7 +104,7 @@ RetinaImage.prototype.swap = function(path) {
 // Bind everything to the window object's onload.
 // This helps wait for the images to get loaded into the DOM.
 
-if (root.devicePixelRatio > 1) {
+if (root.devicePixelRatio > 1 || window.matchMedia('(min-resolution: 1.1dppx)').matches) {
   window.onload = function() {
     var images = document.getElementsByTagName("img"), retinaImages = [], i, image;
     for (i = 0; i < images.length; i++) {


### PR DESCRIPTION
This check enables support for browsers that do not yet support devicePixelRatio but do support media queries in javascript (for example, Firefox).
