### PR TITLE
Fix for bogus whitespace characters

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -5,7 +5,7 @@
 
   function RetinaImagePath(path) {
     this.path = path;
-    this.at_2x_path = path.replace(/\.\w+$/, function(match) { return "@2x" + match; });
+    this.at_2x_path = path.replace(/\.\w+$/, function(match) { return "@2x" + match; });
   }
 
   root.RetinaImagePath = RetinaImagePath;


### PR DESCRIPTION
Thanks for retinajs.  I've fixed the bogus whitespace characters that caused the JavaScript to fail on my Chrome.
