### PR TITLE
Save and call any existing window.onload handler

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -72,12 +72,14 @@
 
 
   if (root.devicePixelRatio > 1) {
+    var existing_onload = window.onload || new Function;
     window.onload = function() {
       var images = document.getElementsByTagName("img"), retinaImages = [], i, image;
       for (i = 0; i < images.length; i++) {
         image = images[i];
         retinaImages.push(new RetinaImage(image));
       }
+      existing_onload();
     }
   }
 


### PR DESCRIPTION
Save off existing handler and call after retina processing is complete.  Put the call after retina processing so we still swap images even if the existing handler throws.
