### PR TITLE
Fixing instruction set in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Will compile to:
 
 ##How to test
 
-We use [mocha](http://visionmedia.github.com/mocha/) for unit testing with [should](https://github.com/visionmedia/should.js) assertions. Install mocha and should by running `npm install`.
+We use [mocha](http://visionmedia.github.com/mocha/) for unit testing with [should](https://github.com/visionmedia/should.js) assertions. Install mocha and should by running `npm install -g mocha`.
 
 To run the test suite:
 


### PR DESCRIPTION
The instruction set only says "npm install," shouldn't it say "npm install -g mocha"?
