### PR TITLE
add an option to choose the path suffix for 2x images

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -6,6 +6,9 @@
     // An option to choose a suffix for 2x images
     retinaImageSuffix : "@2x",
     
+    // An option to select some of the img tags to make their image retina.
+    retinaImgTagSelector : "body img",
+    
     // Ensure Content-Type is an image before trying to load @2x image
     // https://github.com/imulus/retinajs/pull/45)
     check_mime_type: true
@@ -28,7 +31,7 @@
     var existing_onload = context.onload || new Function;
 
     context.onload = function() {
-      var images = document.getElementsByTagName("img"), retinaImages = [], i, image;
+      var images = document.querySelectorAll(config.retinaImgTagSelector), retinaImages = [], i, image;
       for (i = 0; i < images.length; i++) {
         image = images[i];
         retinaImages.push(new RetinaImage(image));


### PR DESCRIPTION
Added an option to choose the path suffix for 2x images.

I'm using _2x path suffix for my retina images, just as www.apple.com does. But this script only works if your retina image suffix is "@2x". So I added an option.

Commit e7930be
Added another option to select just some of the img tags to make their image retina, not all the images on a webpage.
I can see "travis build failed", because of querySelectorAll. Maybe travis is using an old JS engine.
https://developer.mozilla.org/en-US/docs/DOM/Document.querySelectorAll
