### PR TITLE
Allow Query parameters at the end of URLs

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -54,7 +54,7 @@
 
   function RetinaImagePath(path) {
     this.path = path;
-    this.at_2x_path = path.replace(/\.\w+$/, function(match) { return "@2x" + match; });
+    this.at_2x_path = path.replace(/\.[\w\?=]+$/, function(match) { return "@2x" + match; });
   }
 
   RetinaImagePath.confirmed_paths = [];


### PR DESCRIPTION
My images have Query URLs appended to them to get past some annoying proxies that don't always respect headers.

For instance /static/image/logo.png?hash=d41d8cd98f00b204e9800998ecf8427e

The code as written won't detect these URLs, since the ? and = aren't in \w

This patch simply expands the regex slightly to allow those to get through ;)
