### PR TITLE
add an option to choose the suffix for 2x images

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -3,6 +3,9 @@
   var root = (typeof exports == 'undefined' ? window : exports);
 
   var config = {
+    // An option to choose a suffix for 2x images
+    retinaImageSuffix : "@2x",
+    
     // Ensure Content-Type is an image before trying to load @2x image
     // https://github.com/imulus/retinajs/pull/45)
     check_mime_type: true
@@ -54,7 +57,7 @@
 
   function RetinaImagePath(path) {
     this.path = path;
-    this.at_2x_path = path.replace(/\.\w+$/, function(match) { return "@2x" + match; });
+    this.at_2x_path = path.replace(/\.\w+$/, function(match) { return config.retinaImageSuffix + match; });
   }
 
   RetinaImagePath.confirmed_paths = [];


### PR DESCRIPTION
Added an option to choose the path suffix for 2x images.

I'm using _2x path suffix for my retina images, just as www.apple.com does. But this script only works if your retina image suffix is "@2x". So I added an option.
