### PR TITLE
Makes sure that an image has a "src" attributes before trying to retinafy it.

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -28,7 +28,7 @@
       var images = document.getElementsByTagName("img"), retinaImages = [], i, image;
       for (i = 0; i < images.length; i++) {
         image = images[i];
-        retinaImages.push(new RetinaImage(image));
+        if (image.src) retinaImages.push(new RetinaImage(image));
       }
       existing_onload();
     }


### PR DESCRIPTION
I ran into this on a single page app where there was an avatar img bound to a user's avatar url that hadn't been set yet. Even though this is arguably a bit of a weird case, it seems like it shouldn't break retina.js. Since it's an easy fix I decided to send a PR. Love this tool, very awesome. Thanks for sharing.
