### PR TITLE
Feature: Allow for configuration of a custom img tag selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ retina.js makes it easy to serve high-resolution images to devices with retina d
 
 When your users load a page, retina.js checks each image on the page to see if there is a high-resolution version of that image on your server. If a high-resolution variant exists, the script will swap in that image in-place.
 
+You can also specify a custom image tag selector if you want to limit the images for which the script performs this check. This is particularly handy in combination with the `data-at2x` attribute described below.
+
 The script assumes you use Apple's prescribed high-resolution modifier (@2x) to denote high-resolution image variants on your server. It is also possible to override this by manually specifying the URL for the @2x images using `data-at2x` attributes.
 
 For example, if you have an image on your page that looks like this:
@@ -42,6 +44,18 @@ The JavaScript helper script automatically replaces images on your page with hig
 ``` html
 <script type="text/javascript" src="/scripts/retina.js"></script>
 ```
+
+If you want to specify a custom image tag selector then add the following below the script tag:
+
+```html
+<script type="text/javascript">
+    window.Retina.configure({
+        img_tag_selector : 'img[data-at2x]'
+    });
+</script>
+```
+
+This particular selector `img[data-at2x]` will make sure that retina.js only retrieves retina images for those image tags that have the `data-at2x` attribute set.
 
 ###LESS
 

--- a/src/retina.js
+++ b/src/retina.js
@@ -5,7 +5,8 @@
   var config = {
     // Ensure Content-Type is an image before trying to load @2x image
     // https://github.com/imulus/retinajs/pull/45)
-    check_mime_type: true
+    check_mime_type: true,
+    img_tag_selector: 'img'
   };
 
 
@@ -25,7 +26,8 @@
     var existing_onload = context.onload || new Function;
 
     context.onload = function() {
-      var images = document.getElementsByTagName("img"), retinaImages = [], i, image;
+      var images = document.querySelectorAll(config.img_tag_selector),
+          retinaImages = [], i, image;
       for (i = 0; i < images.length; i++) {
         image = images[i];
         retinaImages.push(new RetinaImage(image));

--- a/test/retina.test.js
+++ b/test/retina.test.js
@@ -8,9 +8,12 @@ var Retina = require('../').Retina;
 describe('Retina', function() {
 
   before(function(){
-    // stub out the getElementsByTagName method
     global.document = {
       getElementsByTagName : function(){
+        return [];
+      },
+      querySelectorAll : function (selector){
+        global.document.imgTagSelector = selector;
         return [];
       }
     }
@@ -30,6 +33,11 @@ describe('Retina', function() {
       Retina.init(window);
       window.onload();
       existingOnloadExecutions.should.equal(1);
+    });
+
+    it('uses standard img tag selector by default', function(){
+      Retina.init();
+      global.document.imgTagSelector.should.equal('img');
     });
   });
 


### PR DESCRIPTION
In a scenario where the server side knows which images have high-resolution variants there is currently no way for telling retina.js to only load those files. In this pull request I replaced the hardcoded `img` tag selector with a configurable image selector query.

The canonical use case is that when the server renders the HTML code it adds `data-at2x` attributes to those images for which there are high-resolution variants. If you now configure the custom images selector to `img[data-at2x]` then retina.js will only load retina images where they are indeed available.