### PR TITLE
Solves scaling bug with bordered retina images

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -124,8 +124,8 @@
       if (! that.el.complete) {
         setTimeout(load, 5);
       } else {
-        that.el.setAttribute('width', that.el.offsetWidth);
-        that.el.setAttribute('height', that.el.offsetHeight);
+        that.el.setAttribute('width', that.el.clientWidth);
+        that.el.setAttribute('height', that.el.clientHeight);
         that.el.setAttribute('src', path);
       }
     }

--- a/test/functional/public/index.html
+++ b/test/functional/public/index.html
@@ -13,6 +13,9 @@
         height: auto;
         max-width: 100%;
       }
+      .with-border{
+        border: 2px solid red;
+      }
     </style>
 
     <script type="text/javascript">
@@ -26,6 +29,9 @@
     <img src="google.png" /> <!-- It will find the @2x version of this in the confirmed_paths cache because it is a duplicate -->
     <img src="google@1x.png" /> <!-- This will not be replaced with a retina version-->
     <img src="https://www.google.com/logos/2012/doisneau12-hp.jpg" />
+    <br />
+    <img src="google.png" class="with-border" /> <!-- retina image should be the same size as low res image when border is specified -->
+    <img src="google@1x.png" class="with-border" />
 
     <div class="responsive">
       <img src="ipad_hero.jpeg" />


### PR DESCRIPTION
When applying css border to images the retina.js uses full image dimensions to calculate the size of for the retina image which includes extra border dimension. To exclude borders from retina image calculation we should use clientHeight/Width instead of offsetHeight/Width.