### PR TITLE
Fix: Allows images to be hidden, but still rendered correctly on show.

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -124,8 +124,13 @@
       if (! that.el.complete) {
         setTimeout(load, 5);
       } else {
-        that.el.setAttribute('width', that.el.offsetWidth);
-        that.el.setAttribute('height', that.el.offsetHeight);
+        if (that.el.offsetWidth == 0 && that.el.offsetHeight == 0) {
+          that.el.setAttribute('width', that.el.naturalWidth);
+          that.el.setAttribute('height', that.el.naturalHeight);
+        }else {
+          that.el.setAttribute('width', that.el.offsetWidth);
+          that.el.setAttribute('height', that.el.offsetHeight);
+        }
         that.el.setAttribute('src', path);
       }
     }


### PR DESCRIPTION
CSS can be set as display: none and the image size will still be set correctly.  Example at: http://leve.rs (Slider buttons)
