### PR TITLE
Fix to take advantage of LESS media query nesting

### DIFF
--- a/src/retina.less
+++ b/src/retina.less
@@ -1,7 +1,7 @@
 // retina.less
 // A helper mixin for applying high-resolution background images (http://www.retinajs.com)
 
-@highdpi: ~"(-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx)";
+@highdpi: ~"(-webkit-min-device-pixel-ratio: 1.5)", ~"(min--moz-device-pixel-ratio: 1.5)", ~"(-o-min-device-pixel-ratio: 3/2)", ~"(min-device-pixel-ratio: 1.5)", ~"(min-resolution: 1.5dppx)";
 
 .at2x(@path, @w: auto, @h: auto) {
   background-image: url(@path);


### PR DESCRIPTION
Nesting media queries in less ends with the parent query being placed before the child query. Making the @highdpi a set rather than a single string means that each dpi check will also be nested with the parent query.

Example test:
@media only screen and (max-width: 500px) {
	.element {
		.at2x('images/test.png', 100px, 100px);
	}
}

With original (max width is only applied to the webkit check):
@media only screen and (max-width: 500px) and (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx) {..}

With updated (max width is applied to all checks):
@media only screen and (max-width: 500px) and (-webkit-min-device-pixel-ratio: 1.5), only screen and (max-width: 500px) and (min--moz-device-pixel-ratio: 1.5), only screen and (max-width: 500px) and (-o-min-device-pixel-ratio: 3/2), only screen and (max-width: 500px) and (min-device-pixel-ratio: 1.5), only screen and (max-width: 500px) and (min-resolution: 1.5dppx) {}