### PR TITLE
Support query strings for retina CSS images.

### DIFF
--- a/src/retina.less
+++ b/src/retina.less
@@ -5,7 +5,7 @@
 
 .at2x(@path, @w: auto, @h: auto) {
   background-image: url(@path);
-  @at2x_path: ~`@{path}.replace(/\.\w+$/, function(match) { return "@2x" + match; })`;
+  @at2x_path: ~`@{path}.replace(/\.[\w\?\-]+$/, function(match) { return "@2x" + match; })`;
 
   @media @highdpi {
     background-image: url("@{at2x_path}");


### PR DESCRIPTION
Query strings are often used for cache invalidation of images.
