### PR TITLE
No-op on data uris

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -75,7 +75,7 @@
 
   RetinaImagePath.prototype.check_2x_variant = function(callback) {
     var http, that = this;
-    if (this.is_external()) {
+    if (this.is_external() || this.is_data_uri()) {
       return callback(false);
     } else if (!this.perform_check && typeof this.at_2x_path !== "undefined" && this.at_2x_path !== null) {
       return callback(true);

--- a/test/retina_image_path.test.js
+++ b/test/retina_image_path.test.js
@@ -135,6 +135,15 @@ describe('RetinaImagePath', function() {
       });
     });
 
+    it('should callback with false when #is_data_uri() is true', function(done) {
+      document.domain = "www.apple.com";
+      path = new RetinaImagePath("data:image/png;base64,foobar");
+      path.check_2x_variant(function(hasVariant) {
+        hasVariant.should.equal(false);
+        done();
+      });
+    });
+
     it('should callback with true when at2x is supplied', function(done) {
       path = new RetinaImagePath("/images/some_image.png", "/images/some_image@100x.png");
       path.check_2x_variant(function(hasVariant) {


### PR DESCRIPTION
Currently retinajs prepends the `@2x` to data uris, which breaks them. This patch makes it no-op when it encounters one.
