### PR TITLE
Remove extraneous quotes to url interpolation in scss partial

### DIFF
--- a/src/_retina.scss
+++ b/src/_retina.scss
@@ -8,13 +8,13 @@
   $at1x_path: "#{$path}.#{$ext}";
   $at2x_path: "#{$path}@2x.#{$ext}";
 
-  background-image: "url("#{$at1x_path}")";
+  background-image: url("#{$at1x_path}");
 
   @media all and (-webkit-min-device-pixel-ratio : 1.5),
          all and (-o-min-device-pixel-ratio: 3/2),
          all and (min--moz-device-pixel-ratio: 1.5),
          all and (min-device-pixel-ratio: 1.5) {
-           background-image: "url("#{$at2x_path}")";
+           background-image: url("#{$at2x_path}");
            background-size: $w $h;
   }
 }


### PR DESCRIPTION
Libsass implements interpolation correctly now, so these aren't needed.

https://github.com/hcatlin/libsass/issues/30
