### PR TITLE
Allow some images to not be processed by Retina

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -124,7 +124,7 @@
     function load() {
       if (! that.el.complete) {
         setTimeout(load, 5);
-      } else {
+      } else if (!that.el.getAttribute('data-no-retina')) {
         if (config.force_original_dimensions) {
           that.el.setAttribute('width', that.el.offsetWidth);
           that.el.setAttribute('height', that.el.offsetHeight);


### PR DESCRIPTION
We had a very difficult to track down bug wherein Retina was setting the width and height of an image to 0px after an ng-show trigger. This should not be happening, and one easy fix is to allow individual images to not be processed by Retina.
