### PR TITLE
Defer to the markup's at_2x_path if specified, even if external

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -72,10 +72,10 @@
 
   RetinaImagePath.prototype.check_2x_variant = function(callback) {
     var http, that = this;
-    if (this.is_external()) {
-      return callback(false);
-    } else if (!this.perform_check && typeof this.at_2x_path !== "undefined" && this.at_2x_path !== null) {
+    if (!this.perform_check && typeof this.at_2x_path !== "undefined" && this.at_2x_path !== null) {
       return callback(true);
+    } else if (this.is_external()) {
+      return callback(false);
     } else if (this.at_2x_path in RetinaImagePath.confirmed_paths) {
       return callback(true);
     } else {

--- a/test/retina_image_path.test.js
+++ b/test/retina_image_path.test.js
@@ -123,6 +123,14 @@ describe('RetinaImagePath', function() {
       });
     });
 
+    it('should callback with true when at2x is supplied even if referencing a external over https', function(done){
+      path = new RetinaImagePath("https://google.com/images/some_image.png", "https://google.com/images/some_image_hidpi.png");
+      path.check_2x_variant(function(hasVariant) {
+        hasVariant.should.equal(true);
+        done();
+      });
+    });
+
     it('should callback with false when remote at2x image does not exist', function(done) {
       XMLHttpRequest.status = 404; // simulate a failing request
       XMLHttpRequest.contentType = 'image/png'; // simulate a proper content type


### PR DESCRIPTION
Fixed #122
