### PR TITLE
Use naturalWidth/Height to avoid a wrong size on retina-screens

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -126,8 +126,10 @@
         setTimeout(load, 5);
       } else {
         if (config.force_original_dimensions) {
-          that.el.setAttribute('width', that.el.offsetWidth);
-          that.el.setAttribute('height', that.el.offsetHeight);
+          var width = that.el.naturalWidth || that.el.offsetWidth,
+              height = that.el.naturalHeight || that.el.offsetHeight;
+          that.el.setAttribute('width', width);
+          that.el.setAttribute('height', height);
         }
 
         that.el.setAttribute('src', path);


### PR DESCRIPTION
Fixed an issue where retinajs used the wrong width/height of the image. For more details about this problem takle a look at [Issue #83](https://github.com/imulus/retinajs/issues/83).

[naturalWidth and naturalHeight](http://stackoverflow.com/a/12556377/207704) are used with a fallback to the original offsetWidth and offsetHeight. Tested with Safari 7.0.3, Firefox 28.0 and Chrome 33.0.1750.117 on OS X 10.9.2.
