### PR TITLE
Added check for 2x variant when document is served via file URI scheme

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -104,6 +104,11 @@
             return callback(true);
         } else if (this.at_2x_path in RetinaImagePath.confirmed_paths) {
             return callback(true);
+        } else if (window.location.protocol === 'file:') {
+            var img = new Image();
+            img.src = this.at_2x_path;
+            img.onload = function() { return callback(true); };
+            img.onerror = function() { return callback(false); };
         } else {
             http = new XMLHttpRequest();
             http.open('HEAD', this.at_2x_path);


### PR DESCRIPTION
When a document is not served via a web server (e.g. when it is opened via `file:` URI scheme) retina.js is not able to check if there is a 2x variant of the image available, because the HEAD request only works for HTTP protocol.

I came across this issue when I tried to use this awesome little script on a [Cordova](https://cordova.apache.org/) app to make it look nice on retina displays, but it did not work, because of this issue. Therefore I've patched the script to make it work!