### PR TITLE
Cache for images length onload

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -37,8 +37,8 @@
         var existing_onload = context.onload || function(){};
 
         context.onload = function() {
-            var images = document.getElementsByTagName('img'), retinaImages = [], i, image;
-            for (i = 0; i < images.length; i += 1) {
+            var images = document.getElementsByTagName('img'), imagesLength = images.length, retinaImages = [], i, image;
+            for (i = 0; i < imagesLength; i += 1) {
                 image = images[i];
                 if (!!!image.getAttributeNode('data-no-retina')) {
                     retinaImages.push(new RetinaImage(image));


### PR DESCRIPTION
Cache the images.length value in a variable instead of recalculating on
each loop. Doesn’t make much difference in newer browsers but older
ones can see a large difference. See
https://stackoverflow.com/questions/6973942/is-optimizing-javascript-for-loops-really-necessary
