### PR TITLE
Fixed duplicate calls to callback.

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -111,7 +111,7 @@
             http.open('HEAD', this.at_2x_path);
             http.onreadystatechange = function() {
                 if (http.readyState !== 4) {
-                    return callback(false);
+                    return;
                 }
 
                 if (http.status >= 200 && http.status <= 399) {


### PR DESCRIPTION
The callback should only be called once. As the state will change several times this line was causing the callback to be called several times (each time with argument "false"). We only care about state 4 so we should just return straight away at other times.

This one tripped me up quite a bit when I tried to modify the code to do something if the @2x image didn't exist.