### PR TITLE
The value for src should be ['*'], not ['**']

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
                     archive: 'dist/retina-<%= pkg.version %>.zip'
                 },
                 files: [{
-                    src: ['**'],
+                    src: ['*'],
                     cwd: 'dist/',
                     dest: '/',
                     expand: true


### PR DESCRIPTION
Grunt was dying at this line. Now it doesn't die. 