### PR TITLE
Fix npm install 'No repository field' warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "retina.js",
   "version": "1.3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/imulus/retinajs.git"
+  },
   "devDependencies": {
     "mocha": "*",
     "should": "*",


### PR DESCRIPTION
Fix warning during npm install:

```
npm WARN package.json retina.js@1.1.0 No repository field.
```