### PR TITLE
Add Option for choose which image to load

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -10,7 +10,12 @@
 
         // Resize high-resolution images to original image's pixel dimensions
         // https://github.com/imulus/retinajs/issues/8
-        force_original_dimensions: true
+        force_original_dimensions: true,
+        
+        // Option for choose which image to load
+        // Default is load all retina images without attr data-no-retina
+        // Provide second option for load only images with attr data-at2x (for manual) and attr data-retina-true for automate find retina images
+        retina_mode: 1, // 2 for secondary option
     };
 
     function Retina() {}
@@ -33,18 +38,26 @@
         if (context === null) {
             context = root;
         }
-        context.addEventListener('load', function (){
-            var images = document.getElementsByTagName('img'), imagesLength = images.length, retinaImages = [], i, image;
-            for (i = 0; i < imagesLength; i += 1) {
-                image = images[i];
 
-                if (!!!image.getAttributeNode('data-no-retina')) {
-                    if (image.src) {
+        var existing_onload = context.onload || function(){};
+
+        context.onload = function() {
+            var images = document.getElementsByTagName('img'), retinaImages = [], i, image;
+            for (i = 0; i < images.length; i += 1) {
+                image = images[i];
+                if( config.retina_mode == 1 ) {
+                    if (!!!image.getAttributeNode('data-no-retina')) {
+                        retinaImages.push(new RetinaImage(image));
+                    } 
+                }
+                else if (config.retina_mode == 2 ) {
+                    if (image.getAttributeNode('data-retina-true') || image.getAttributeNode('data-at2x')) {
                         retinaImages.push(new RetinaImage(image));
                     }
                 }
             }
-        });
+            existing_onload();
+        };
     };
 
     Retina.isRetina = function(){
@@ -62,7 +75,7 @@
     };
 
 
-    var regexMatch = /\.[\w\?=]+$/;
+    var regexMatch = /\.\w+$/;
     function suffixReplace (match) {
         return config.retinaImageSuffix + match;
     }
@@ -97,12 +110,12 @@
 
     RetinaImagePath.prototype.check_2x_variant = function(callback) {
         var http, that = this;
-        if (!this.perform_check && typeof this.at_2x_path !== 'undefined' && this.at_2x_path !== null) {
+        if (this.is_external()) {
+            return callback(false);
+        } else if (!this.perform_check && typeof this.at_2x_path !== 'undefined' && this.at_2x_path !== null) {
             return callback(true);
         } else if (this.at_2x_path in RetinaImagePath.confirmed_paths) {
             return callback(true);
-        } else if (this.is_external()) {
-            return callback(false);
         } else {
             http = new XMLHttpRequest();
             http.open('HEAD', this.at_2x_path);
@@ -129,6 +142,7 @@
         }
     };
 
+
     function RetinaImage(el) {
         this.el = el;
         this.path = new RetinaImagePath(this.el.getAttribute('src'), this.el.getAttribute('data-at2x'));
@@ -153,13 +167,8 @@
                 setTimeout(load, 5);
             } else {
                 if (config.force_original_dimensions) {
-                    if (that.el.offsetWidth == 0 && that.el.offsetHeight == 0) {
-                        that.el.setAttribute('width', that.el.naturalWidth);
-                        that.el.setAttribute('height', that.el.naturalHeight);
-                    } else {
-                        that.el.setAttribute('width', that.el.offsetWidth);
-                        that.el.setAttribute('height', that.el.offsetHeight);
-                    }
+                    that.el.setAttribute('width', that.el.offsetWidth);
+                    that.el.setAttribute('height', that.el.offsetHeight);
                 }
 
                 that.el.setAttribute('src', path);

--- a/src/retina.js
+++ b/src/retina.js
@@ -15,7 +15,7 @@
         // Option for choose which image to load
         // Default is load all retina images without attr data-no-retina
         // Provide second option for load only images with attr data-at2x (for manual) and attr data-retina-true for automate find retina images
-        retina_mode: 1, // 2 for secondary option
+        retina_mode: 2, // 2 for secondary option
     };
 
     function Retina() {}


### PR DESCRIPTION
 Default is load all retina images without attr data-no-retina
Provide second option for load only images with attr data-at2x (for manual) and attr data-retina-true for automate find retina images