### PR TITLE
fix external detection for url started with //

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -92,7 +92,7 @@
     RetinaImagePath.confirmed_paths = [];
 
     RetinaImagePath.prototype.is_external = function() {
-        return !!(this.path.match(/^https?\:/i) && !this.path.match('//' + document.domain) );
+        return !!(this.path.match(/^(https?\:|\/\/)/i) && !this.path.match('//' + document.domain) );
     };
 
     RetinaImagePath.prototype.check_2x_variant = function(callback) {

--- a/test/retina_image_path.test.js
+++ b/test/retina_image_path.test.js
@@ -61,6 +61,12 @@ describe('RetinaImagePath', function() {
       path.is_external().should.equal(true);
     });
 
+    it('should return true when image path references a remote domain with // instead of http(s)', function() {
+      document.domain = "www.apple.com";
+      path = new RetinaImagePath("//google.com/images/some_image.png");
+      path.is_external().should.equal(true);
+    });
+
     it('should return true when image path is a remote domain with www and domain is localhost', function() {
       document.domain = "localhost";
       path = new RetinaImagePath("http://www.google.com/images/some_image.png");


### PR DESCRIPTION
There is an error: if href starts with // instead of http(-s), it isn't detected as external. 
I've added the fix and spec for this case.
